### PR TITLE
Use correct config value to determine telemetry usage

### DIFF
--- a/src/Telemetry/TelemetryManager.php
+++ b/src/Telemetry/TelemetryManager.php
@@ -13,7 +13,7 @@ class TelemetryManager extends Manager
     public function __construct($app)
     {
         parent::__construct($app);
-        $this->telemetryEnabled = config('idempotency.enabled');
+        $this->telemetryEnabled = config('idempotency.telemetry.enabled');
     }
 
     public function getDefaultDriver()


### PR DESCRIPTION
the value of `idempotenty.enabled` is used for the telemetry manager, while it should use the `idempotenty.telemetry.enabled` value as you want to be able to use idempotentcy without telemetry