### PR TITLE
Add check for idempotency configuration

### DIFF
--- a/src/Middleware/EnsureIdempotency.php
+++ b/src/Middleware/EnsureIdempotency.php
@@ -38,6 +38,10 @@ class EnsureIdempotency
      */
     public function handle(Request $request, Closure $next): mixed
     {
+        if (!config('idempotency.enabled')) {
+            return $next($request);
+        }
+        
         $this->startTime = microtime(true);
         $this->initializeTelemetry($request);
 


### PR DESCRIPTION
idempotency has the `enabled` config, but doesn't use it to determine if it should do anything