### PR TITLE
Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/events": "^9.0|^10.0|^11.0|^12.0",
-        "illuminate/http": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/events": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "inspector-apm/inspector-laravel": "^4.11"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Adds Laravel 13 support by extending the supported `illuminate/*` package constraints to `^13.0`.

The change keeps backward compatibility with Laravel 9–12 and only updates Composer version constraints for:

- `illuminate/support`
- `illuminate/events`
- `illuminate/http`

No application logic was changed.