### PR TITLE
feat: allow configurable cache store for idempotency data

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -42,6 +42,9 @@ return [
     
     // How long to cache idempotent responses (in minutes)
     'ttl' => env('IDEMPOTENCY_TTL', 1440), // 24 hours
+
+    // Cache store to use (null = default store)
+    'cache_store' => env('IDEMPOTENCY_CACHE_STORE', null),
     
     // Validation settings
     'validation' => [
@@ -68,6 +71,36 @@ return [
     ],
 ];
 ```
+## Using a Dedicated Cache Store
+
+By default the middleware uses your application's default cache store. This means running `php artisan cache:clear` will also wipe cached idempotency responses. To avoid this, point the package at its own store:
+
+1. Define a new store in `config/cache.php`:
+
+```php
+'stores' => [
+    // ... your other stores ...
+
+    'idempotency' => [
+        'driver' => 'redis',
+        'connection' => 'default',
+        'prefix' => 'idempotency',
+    ],
+],
+```
+
+2. Set the store in `config/idempotency.php` (or via `.env`):
+
+```php
+'cache_store' => env('IDEMPOTENCY_CACHE_STORE', 'idempotency'),
+```
+
+```env
+IDEMPOTENCY_CACHE_STORE=idempotency
+```
+
+Now `php artisan cache:clear` only clears the default store, leaving idempotency data intact.
+
 ## Usage
 Add the middleware to your routes or route groups in your routes/api.php file:
 ```php

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -101,6 +101,12 @@ IDEMPOTENCY_CACHE_STORE=idempotency
 
 Now `php artisan cache:clear` only clears the default store, leaving idempotency data intact.
 
+To clear the idempotency cache when needed, target the store explicitly:
+
+```bash
+php artisan cache:clear --store=idempotency
+```
+
 ## Usage
 Add the middleware to your routes or route groups in your routes/api.php file:
 ```php

--- a/src/Logging/AlertDispatcher.php
+++ b/src/Logging/AlertDispatcher.php
@@ -2,11 +2,19 @@
 
 namespace Infinitypaul\Idempotency\Logging;
 
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Repository as CacheStore;
 use Infinitypaul\Idempotency\Events\IdempotencyAlertFired;
 
 class AlertDispatcher
 {
+    private CacheManager $cacheManager;
+
+    public function __construct(?CacheManager $cacheManager = null)
+    {
+        $this->cacheManager = $cacheManager ?? app(CacheManager::class);
+    }
+
     public function dispatch($eventType, $context = []): void
     {
         if (! $this->shouldSendAlert($eventType, $context)) {
@@ -14,6 +22,11 @@ class AlertDispatcher
         }
 
         event(new IdempotencyAlertFired($eventType, $context));
+    }
+
+    private function cache(): CacheStore
+    {
+        return $this->cacheManager->store(config('idempotency.cache_store'));
     }
 
     /**
@@ -24,12 +37,12 @@ class AlertDispatcher
         $hashKey = md5($eventType . ':' . json_encode($context));
         $cacheKey = "idempotency:alert_sent:{$hashKey}";
 
-        if (Cache::has($cacheKey)) {
+        if ($this->cache()->has($cacheKey)) {
             return false;
         }
 
         $cooldown = config("idempotency.alerts.threshold", 60);
-        Cache::put($cacheKey, true, now()->addMinutes($cooldown));
+        $this->cache()->put($cacheKey, true, now()->addMinutes($cooldown));
 
         return true;
     }

--- a/src/Middleware/EnsureIdempotency.php
+++ b/src/Middleware/EnsureIdempotency.php
@@ -4,11 +4,12 @@ namespace Infinitypaul\Idempotency\Middleware;
 
 use Closure;
 use Exception;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Repository as CacheStore;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Infinitypaul\Idempotency\Logging\AlertDispatcher;
 use Infinitypaul\Idempotency\Logging\EventType;
 use Infinitypaul\Idempotency\Telemetry\TelemetryManager;
@@ -20,12 +21,19 @@ class EnsureIdempotency
     private const PROCESSING_TTL_MINUTES = 5;
 
     private TelemetryManager $telemetryManager;
+    private CacheManager $cacheManager;
     private mixed $segment;
     private float $startTime;
 
-    public function __construct(TelemetryManager $telemetryManager)
+    public function __construct(TelemetryManager $telemetryManager, CacheManager $cacheManager)
     {
         $this->telemetryManager = $telemetryManager;
+        $this->cacheManager = $cacheManager;
+    }
+
+    private function cache(): CacheStore
+    {
+        return $this->cacheManager->store(config('idempotency.cache_store'));
     }
 
     /**
@@ -62,7 +70,7 @@ class EnsureIdempotency
         $keys = $this->generateCacheKeys($idempotencyKey);
 
         // Check for cached response
-        if (Cache::has($keys['response'])) {
+        if ($this->cache()->has($keys['response'])) {
             return $this->handleCachedResponse($keys, $idempotencyKey, $request);
         }
 
@@ -187,7 +195,7 @@ class EnsureIdempotency
      */
     private function handleCachedResponse(array $keys, string $idempotencyKey, Request $request): mixed
     {
-        $storedHash = Cache::get($keys['payload_hash']);
+        $storedHash = $this->cache()->get($keys['payload_hash']);
         $currentHash = md5(json_encode($request->all()));
 
         if ($storedHash !== $currentHash) {
@@ -217,7 +225,7 @@ class EnsureIdempotency
 
         $this->checkAlertThreshold($metadata, $idempotencyKey, $request);
 
-        $response = Cache::get($keys['response']);
+        $response = $this->cache()->get($keys['response']);
         $this->addIdempotencyHeaders($response, $idempotencyKey, 'Repeated');
 
         return $response;
@@ -231,7 +239,7 @@ class EnsureIdempotency
      */
     private function updateMetadata(string $metadataKey): array
     {
-        $metadata = Cache::get($metadataKey, [
+        $metadata = $this->cache()->get($metadataKey, [
             'created_at' => now()->subMinutes(1)->timestamp,
             'hit_count' => 0,
         ]);
@@ -239,7 +247,7 @@ class EnsureIdempotency
         $metadata['hit_count']++;
         $metadata['last_hit_at'] = now()->timestamp;
 
-        Cache::put(
+        $this->cache()->put(
             $metadataKey,
             $metadata,
             now()->addMinutes(config('idempotency.ttl'))
@@ -299,7 +307,7 @@ class EnsureIdempotency
      */
     private function handleNewRequest(array $keys, string $idempotencyKey, Closure $next, Request $request): mixed
     {
-        $lock = Cache::lock($keys['lock'], $this->getLockTimeout());
+        $lock = $this->cache()->lock($keys['lock'], $this->getLockTimeout());
         $lockAcquired = false;
         $lockAcquisitionStart = microtime(true);
 
@@ -312,7 +320,7 @@ class EnsureIdempotency
 
             if (!$lockAcquired) {
                 // Check if response was cached while waiting for lock
-                if (Cache::has($keys['response'])) {
+                if ($this->cache()->has($keys['response'])) {
                     return $this->handleLateCachedResponse($keys, $idempotencyKey);
                 }
 
@@ -325,7 +333,7 @@ class EnsureIdempotency
             }
 
             // Double check if response was cached after we acquired the lock
-            if (Cache::has($keys['response'])) {
+            if ($this->cache()->has($keys['response'])) {
                 return $this->handleLateCachedResponse($keys, $idempotencyKey);
             }
 
@@ -336,7 +344,7 @@ class EnsureIdempotency
             $this->logException($idempotencyKey, $e);
             throw $e;
         } finally {
-            Cache::forget($keys['processing']);
+            $this->cache()->forget($keys['processing']);
             if ($lockAcquired) {
                 $lock->release();
             }
@@ -364,12 +372,12 @@ class EnsureIdempotency
         $telemetry->addSegmentContext($this->segment, 'lock_wait_time_ms', $lockAcquisitionTime * 1000);
 
         // Check if a response was cached while waiting for the lock
-        if (Cache::has($keys['response'])) {
+        if ($this->cache()->has($keys['response'])) {
             return $this->handleLateCachedResponse($keys, $idempotencyKey);
         }
 
         // Check if another request is currently processing this key
-        if (Cache::has($keys['processing'])) {
+        if ($this->cache()->has($keys['processing'])) {
             return $this->handleConcurrentConflict($idempotencyKey, $request);
         }
 
@@ -391,7 +399,7 @@ class EnsureIdempotency
         $telemetry->addSegmentContext($this->segment, 'status', 'late_duplicate');
         $telemetry->endSegment($this->segment);
 
-        $response = Cache::get($keys['response']);
+        $response = $this->cache()->get($keys['response']);
         $this->addIdempotencyHeaders($response, $idempotencyKey, 'Repeated');
 
         return $response;
@@ -463,10 +471,10 @@ class EnsureIdempotency
     private function processRequest(array $keys, string $idempotencyKey, Closure $next, Request $request): mixed
     {
         try {
-            Cache::put($keys['processing'], true, now()->addMinutes($this->getProcessingTtl()));
+            $this->cache()->put($keys['processing'], true, now()->addMinutes($this->getProcessingTtl()));
 
             $payloadHash = md5(json_encode($request->all()));
-            Cache::put($keys['payload_hash'], $payloadHash, now()->addMinutes(config('idempotency.ttl')));
+            $this->cache()->put($keys['payload_hash'], $payloadHash, now()->addMinutes(config('idempotency.ttl')));
 
             $this->setRequestMetadata($keys['metadata'], $request);
 
@@ -510,7 +518,7 @@ class EnsureIdempotency
      */
     private function setRequestMetadata(string $metadataKey, Request $request): void
     {
-        Cache::put(
+        $this->cache()->put(
             $metadataKey,
             [
                 'created_at' => now()->timestamp,
@@ -536,7 +544,7 @@ class EnsureIdempotency
         $cacheableResponse = $this->prepareCacheableResponse($response);
 
         try {
-            Cache::put(
+            $this->cache()->put(
                 $cacheKey,
                 $cacheableResponse,
                 now()->addMinutes(config('idempotency.ttl'))

--- a/src/config/idempotency.php
+++ b/src/config/idempotency.php
@@ -107,6 +107,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | The cache store to use for idempotency data. Set this to a dedicated
+    | store (e.g. 'idempotency') so that running `php artisan cache:clear`
+    | does not wipe out cached idempotency responses.
+    | When null, the application's default cache store is used.
+    |
+    */
+    'cache_store' => env('IDEMPOTENCY_CACHE_STORE', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Header Name
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/CustomCacheStoreTest.php
+++ b/tests/Feature/CustomCacheStoreTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Infinitypaul\Idempotency\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Infinitypaul\Idempotency\Middleware\EnsureIdempotency;
+use Infinitypaul\Idempotency\Tests\TestCase;
+
+class CustomCacheStoreTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(EnsureIdempotency::class)->post('/test-endpoint', function (Request $request) {
+            return response()->json(['message' => 'processed', 'amount' => $request->input('amount')]);
+        });
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('cache.stores.idempotency', [
+            'driver' => 'array',
+        ]);
+
+        $app['config']->set('idempotency.cache_store', 'idempotency');
+    }
+
+    public function test_idempotency_uses_configured_cache_store(): void
+    {
+        $key = (string) Str::uuid();
+        $payload = ['amount' => 500];
+
+        $first = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $first->assertStatus(200);
+        $first->assertHeader('Idempotency-Status', 'Original');
+
+        $second = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $second->assertStatus(200);
+        $second->assertHeader('Idempotency-Status', 'Repeated');
+    }
+
+    public function test_data_is_stored_in_configured_store_not_default(): void
+    {
+        $key = (string) Str::uuid();
+        $payload = ['amount' => 500];
+
+        $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+
+        $responseKey = "idempotency:{$key}:response";
+
+        $this->assertTrue(Cache::store('idempotency')->has($responseKey));
+        $this->assertFalse(Cache::store('array')->has($responseKey));
+    }
+
+    public function test_clearing_default_store_does_not_affect_idempotency(): void
+    {
+        $key = (string) Str::uuid();
+        $payload = ['amount' => 750];
+
+        $first = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $first->assertStatus(200);
+        $first->assertHeader('Idempotency-Status', 'Original');
+
+        Cache::store('array')->flush();
+
+        $second = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $second->assertStatus(200);
+        $second->assertHeader('Idempotency-Status', 'Repeated');
+    }
+
+    public function test_null_cache_store_uses_default(): void
+    {
+        config(['idempotency.cache_store' => null]);
+
+        $key = (string) Str::uuid();
+        $payload = ['amount' => 100];
+
+        $first = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $first->assertStatus(200);
+        $first->assertHeader('Idempotency-Status', 'Original');
+
+        $second = $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+        $second->assertStatus(200);
+        $second->assertHeader('Idempotency-Status', 'Repeated');
+    }
+
+    public function test_payload_mismatch_detected_with_custom_store(): void
+    {
+        $key = (string) Str::uuid();
+
+        $first = $this->postJson('/test-endpoint', ['amount' => 100], ['Idempotency-Key' => $key]);
+        $first->assertStatus(200);
+
+        $second = $this->postJson('/test-endpoint', ['amount' => 999], ['Idempotency-Key' => $key]);
+        $second->assertStatus(422);
+        $second->assertJson(['error' => 'Idempotency-Key reused with different request payload']);
+    }
+
+    public function test_metadata_stored_in_configured_store(): void
+    {
+        $key = (string) Str::uuid();
+        $payload = ['amount' => 200];
+
+        $this->postJson('/test-endpoint', $payload, ['Idempotency-Key' => $key]);
+
+        $metadataKey = "idempotency:{$key}:metadata";
+        $metadata = Cache::store('idempotency')->get($metadataKey);
+
+        $this->assertNotNull($metadata);
+        $this->assertArrayHasKey('created_at', $metadata);
+        $this->assertArrayHasKey('hit_count', $metadata);
+        $this->assertEquals(0, $metadata['hit_count']);
+    }
+}

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -54,4 +54,9 @@ class ConfigTest extends TestCase
     {
         $this->assertEquals('null', config('idempotency.telemetry.driver'));
     }
+
+    public function test_cache_store_defaults_to_null(): void
+    {
+        $this->assertNull(config('idempotency.cache_store'));
+    }
 }


### PR DESCRIPTION
Adds a `cache_store` config option so idempotency data can be stored in a dedicated cache store, preventing `php artisan cache:clear` from wiping cached responses. Resolves #2.